### PR TITLE
Now Prometheus use double-dash to flags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - "./config:/config"
       - "./data/prometheus:/data"
-    command: -config.file=/config/prometheus.yml -storage.local.path=/data -storage.local.retention=5000h -alertmanager.url=http://alertmanager:9093
+    command: --config.file=/config/prometheus.yml --storage.local.path=/data --storage.local.retention=5000h --alertmanager.url=http://alertmanager:9093
   blackbox_exporter:
     image: prom/blackbox-exporter
     ports:
@@ -22,7 +22,7 @@ services:
       - "9115:9115"
     volumes:
       - "./config:/config"
-    command: -config.file=/config/blackbox.yml
+    command: --config.file=/config/blackbox.yml
   alertmanager:
     image: prom/alertmanager
     restart: always
@@ -33,7 +33,7 @@ services:
     volumes:
       - "./data/alertmanager:/data"
       - "./config:/config"
-    command: -config.file=/config/alertmanager.yml -storage.path=/data
+    command: --config.file=/config/alertmanager.yml --storage.path=/data
   flakyhost.com:
     environment:
       - HITS_FAIL_COUNT=10


### PR DESCRIPTION
To avoid the error "unknown short flag '-c', try --help", as reported in https://prometheus.io/blog/2017/06/21/prometheus-20-alpha3-new-rule-format/#flag-changes, Prometheus now use double-dash instead of single dash to catch the flags.